### PR TITLE
Fixes include path for flexslider2 css+js

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -328,6 +328,6 @@ tt_content.gridelements_pi1.20.10.setup {
  * CSS and JS for flexslider (content slider grid)
  */
 page {
-    includeCSS.flexslider2 = /typo3conf/ext/bootstrap_grids/Resources/Public/Flexslider2/flexslider.css
-    includeJSFooterlibs.flexslider2 = /typo3conf/ext/bootstrap_grids/Resources/Public/Flexslider2/jquery.flexslider-min.js
+    includeCSS.flexslider2 = typo3conf/ext/bootstrap_grids/Resources/Public/Flexslider2/flexslider.css
+    includeJSFooterlibs.flexslider2 = typo3conf/ext/bootstrap_grids/Resources/Public/Flexslider2/jquery.flexslider-min.js
 }


### PR DESCRIPTION
The paths of the assets should be relatively. If absolutely, the integration does not work if the CMS is in a subfolder installed (For example: http: //example.tld/hello-world/index.php).