### PR TITLE
Adding a hint to the order of static templates

### DIFF
--- a/Documentation/Main/Administration/Index.rst
+++ b/Documentation/Main/Administration/Index.rst
@@ -16,7 +16,7 @@ Installation
 
 - Install the extension. If gridelements is not installed yet, it will be installed automatically.
 
-- Include the static templates as shown in the screenshot.
+- Include the static templates as shown in the screenshot. Keep in mind that the order of templates is important!
 
 |img-includestatic|
 


### PR DESCRIPTION
This small hint would have saved me a lot of time because I forgot that the order is indeed important.