### PR TITLE
Added bootstrap carousel

### DIFF
--- a/Configuration/FlexForm/flexform_carousel.xml
+++ b/Configuration/FlexForm/flexform_carousel.xml
@@ -1,0 +1,161 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT type="array">
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.sheet.animation</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el type="array">
+                    <slidespeed type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.slider.speed</label>
+                            <config type="array">
+                                <type>input</type>
+                                <size>5</size>
+                                <max>8</max>
+                                <default>5000</default>
+                                <range>
+                                    <lower>500</lower>
+                                </range>
+                                <eval>int</eval>
+                            </config>
+                        </TCEforms>
+                    </slidespeed>
+                    <style type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.slider.style</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.none</numIndex>
+                                        <numIndex index="1">1</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">Style 2</numIndex>
+                                        <numIndex index="1">2</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </style>
+                </el>
+            </ROOT>
+        </sDEF>
+        <scontrols>
+            <ROOT type="array">
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.sheet.controls</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el type="array">
+                    <showcontrolnav type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.slider.showcontrolnav</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.yes</numIndex>
+                                        <numIndex index="1">true</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.no</numIndex>
+                                        <numIndex index="1">false</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </showcontrolnav>
+                    <showdirnav type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.slider.showdirnav</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.no</numIndex>
+                                        <numIndex index="1">false</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.yes</numIndex>
+                                        <numIndex index="1">true</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </showdirnav>
+                     <pauseonhover type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.slider.pauseonhover</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.yes</numIndex>
+                                        <numIndex index="1">true</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.no</numIndex>
+                                        <numIndex index="1">false</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </pauseonhover>
+                </el>
+            </ROOT>
+        </scontrols>
+        <soptions>
+            <ROOT type="array">
+                <TCEforms>
+                    <sheetTitle>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.sheet.options</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el type="array">
+                    <wrap type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.carousel.wrap</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.yes</numIndex>
+                                        <numIndex index="1">true</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.no</numIndex>
+                                        <numIndex index="1">false</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </wrap>
+                    <keyboard type="array">
+                        <TCEforms type="array">
+                            <label>LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.carousel.keyboard</label>
+                            <config type="array">
+                                <type>select</type>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.yes</numIndex>
+                                        <numIndex index="1">true</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:grid.label.no</numIndex>
+                                        <numIndex index="1">false</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </keyboard>
+                </el>
+            </ROOT>
+        </soptions>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -304,7 +304,118 @@ lib.bootstrap_grids {
             40 = TEXT
             40.value = });
         }
+    }
 
+    # Carousel
+    carousel < lib.gridelements.defaultGridSetup
+    carousel {
+        columns {
+            101 < .default
+            101 {
+                renderObj {
+                    5 = LOAD_REGISTER
+                    5 {
+                        caruselCount {
+                            cObject = TEXT
+                            cObject {
+                                data = register:caruselCount
+                                wrap = |+1
+                            }
+                            prioriCalc = intval
+                        }
+                    }
+                    stdWrap.insertData = 1
+                    stdWrap.outerWrap.cObject = CASE
+                    stdWrap.outerWrap.cObject {
+                        key.data = register:caruselCount
+                        default = TEXT
+                        default.value = <div class="item">|</div>
+                        1 = TEXT
+                        1.value = <div class="item active">|</div>
+                    }
+                }
+
+                wrap = <div class="carousel-inner" role="listbox">|</div>
+            }
+        }
+
+        prepend = COA
+        prepend {
+            10 = TEXT
+            10 {
+                value = <div id="carousel{field:uid}" class="carousel slide style{field:flexform_style}" data-ride="carousel" data-interval="{field:flexform_slidespeed}" data-wrap="{field:flexform_wrap}" data-keyboard="{field:flexform_keyboard}">
+                insertData = 1
+            }
+
+            20 = CONTENT
+            20 {
+                table = tt_content
+                select {
+                    selectFields = header, uid, tx_gridelements_container, sorting
+                    where = 1=1
+                    andWhere = tx_gridelements_container={field:uid}
+                    andWhere.insertData = 1
+                    orderBy = sorting
+                }
+                wrap = <ol class="carousel-indicators">|</ol>
+                renderObj = COA
+                renderObj {
+                    5 = LOAD_REGISTER
+                    5.caruselCount2 {
+                        cObject = TEXT
+                        cObject.data = register:caruselCount2
+                        prioriCalc = intval
+                    }
+                    10 = TEXT
+                    10 {
+                        data = register:caruselCount2
+                        insertData = 1
+                        outerWrap.cObject = CASE
+                        outerWrap.cObject {
+                            key.data = register:caruselCount2
+                            default = TEXT
+                            default.value = <li data-target="#carousel{field:tx_gridelements_container}" data-slide-to="|"></li>
+                            0 = TEXT
+                            0.value = <li data-target="#carousel{field:tx_gridelements_container}" data-slide-to="|" class="active"></li>
+                        }
+                    }
+                    15 = LOAD_REGISTER
+                    15.caruselCount2 {
+                        cObject = TEXT
+                        cObject.data = register:caruselCount2
+                        cObject.wrap = |+1
+                        prioriCalc = intval
+                    }
+                }
+            }
+        }
+
+        append = COA
+        append {
+            30 = TEXT
+            30 {
+                stdWrap {
+                    wrap (
+                        <a class="left carousel-control" href="#carousel{field:uid}" role="button" data-slide="prev">
+                            <span class="glyphicon glyphicon-chevron-left" aria-hidden="true"></span>
+                            <span class="sr-only">Previous</span>
+                        </a>
+                        <a class="right carousel-control" href="#carousel{field:uid}" role="button" data-slide="next">
+                            <span class="glyphicon glyphicon-chevron-right" aria-hidden="true"></span>
+                            <span class="sr-only">Next</span>
+                        </a>
+                    )
+                    insertData = 1
+                    if {
+                        value = true
+                        equals.field = flexform_showdirnav
+                    }
+                }
+            }
+
+            40 = TEXT
+            40.value = </div>
+        }
     }
 
     # simple row for content elements and usage with ext:bscolwrap
@@ -330,6 +441,7 @@ tt_content.gridelements_pi1.20.10.setup {
     4cols < lib.bootstrap_grids.4cols
     accordion < lib.bootstrap_grids.accordion
     slider < lib.bootstrap_grids.slider
+    carousel < lib.bootstrap_grids.carousel
     tabsSimple < lib.bootstrap_grids.simpleTabs
     tabs4 < lib.bootstrap_grids.4tabs
     tabs6 < lib.bootstrap_grids.6tabs

--- a/Configuration/TypoScript/tsconfig.ts
+++ b/Configuration/TypoScript/tsconfig.ts
@@ -223,5 +223,22 @@ tx_gridelements {
             }
             flexformDS = FILE:EXT:bootstrap_grids/Configuration/FlexForm/flexform_slider.xml
         }
+
+        carousel {
+            title = LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:carousel.title
+            description = LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:carousel.description
+            icon = EXT:bootstrap_grids/Resources/Public/Icons/grid_slider.png
+            frame = 1
+            topLevelLayout = 0
+            config {
+                colCount = 1
+                rowCount = 1
+                rows.1.columns.1 {
+                    name = LLL:EXT:bootstrap_grids/Resources/Private/Language/locallang_db.xlf:celayout.carouselElements
+                    colPos = 101
+                }
+            }
+            flexformDS = FILE:EXT:bootstrap_grids/Configuration/FlexForm/flexform_carousel.xml
+        }
     }
 }

--- a/Resources/Private/Language/locallang_db.xlf
+++ b/Resources/Private/Language/locallang_db.xlf
@@ -51,6 +51,12 @@
             <trans-unit id="slider.description" xml:space="preserve">
 				<source>Each content element within the grid represents a slider element.</source>
 			</trans-unit>
+	        <trans-unit id="carousel.title" xml:space="preserve">
+				<source>Content carousel</source>
+			</trans-unit>
+            <trans-unit id="carousel.description" xml:space="preserve">
+				<source>Each content element within the grid represents a carousel element.</source>
+			</trans-unit>
 
             <trans-unit id="xSimpleRow.title" xml:space="preserve">
 				<source>Row</source>
@@ -100,6 +106,9 @@
             </trans-unit>
             <trans-unit id="celayout.sliderElements" xml:space="preserve">
 				<source>Slider elements</source>
+            </trans-unit>
+	        <trans-unit id="celayout.carouselElements" xml:space="preserve">
+				<source>Carousel elements</source>
             </trans-unit>
             <trans-unit id="celayout.columnElements" xml:space="preserve">
 				<source>Column elements</source>
@@ -214,6 +223,14 @@
 			<trans-unit id="grid.slider.reverse" xml:space="preserve">
 				<source>Reverse order</source>
 			</trans-unit>
+
+	        <trans-unit id="grid.carousel.wrap" xml:space="preserve">
+				<source>Cycle continuously</source>
+			</trans-unit>
+	        <trans-unit id="grid.carousel.keyboard" xml:space="preserve">
+				<source>React on keyboard events</source>
+			</trans-unit>
+
 
             <trans-unit id="grid.sheet.layout" xml:space="preserve">
 				<source>Layout</source>


### PR DESCRIPTION
I added a new type: carousel, implementing the default http://getbootstrap.com/javascript/#carousel
I did reuse some of the slider labels and also the content type icon, maybe there should be a different one for that. I assume css/js stuff is loaded externally as with the other elements like tabs and accordions.
