### PR TITLE
include flexslider as a normal JSFooter File

### DIFF
--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -341,5 +341,5 @@ tt_content.gridelements_pi1.20.10.setup {
  */
 page {
     includeCSS.flexslider2 = EXT:bootstrap_grids/Resources/Public/Flexslider2/flexslider.css
-    includeJSFooterlibs.flexslider2 = EXT:bootstrap_grids/Resources/Public/Flexslider2/jquery.flexslider-min.js
+    includeJSFooter.flexslider2 = EXT:bootstrap_grids/Resources/Public/Flexslider2/jquery.flexslider-min.js
 }


### PR DESCRIPTION
Lets not include the flexslider file as a Lib. It could lead to conflict with the order of integrated Libs (for example, jQuery as a FooterLib being included AFTER the flexslider file, which could result in a jQuery not defined error). Or would you define the flexslider plugin as a LIB?
