### PR TITLE
Typo3 8.7 LTS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+#Editos
+.idea

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,11 @@
   "support": {
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
+  "require": {
+    "php": ">=5.5.0",
+    "typo3/cms": "^7.6 || ^8.7",
+    "gridelementsteam/gridelements" : "dev-master"
+  },
   "autoload": {
     "psr-4": {
       "Laxap\\BootstrapGrids\\": "Classes"

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '8.7.0-8.7.99',
-			'gridelements' => '8.0.0-0.0.0',
+			'gridelements' => '8.0.0-0.0.0|8.0.0-dev',
 		],
 		'conflicts' => [
 		],


### PR DESCRIPTION
To enable Typo3 8.7 LTS support, we first need to add the requirements to composer.json and update the dependencies in ext_emconf.  

Updated dependencies constrains for gridelements
Added composer support
Added gitignore file