### PR TITLE
fix double screen name sizes in DE

### DIFF
--- a/Resources/Private/Language/de.locallang_db.xlf
+++ b/Resources/Private/Language/de.locallang_db.xlf
@@ -83,10 +83,10 @@
 			<target state="translated">Mobilgeräte</target></trans-unit>
             <trans-unit id="grid.sheet.largeDevices" xml:space="preserve" approved="yes">
 				<source>Large</source>
-			<target state="translated">Grosse Screens</target></trans-unit>
+			<target state="translated">WQHD(2,56K)</target></trans-unit>
             <trans-unit id="grid.sheet.extraLargeDevices" xml:space="preserve" approved="yes">
 				<source>Extra Large</source>
-			<target state="translated">Grosse Screens</target></trans-unit>
+			<target state="translated">UltraHD(4K)</target></trans-unit>
             <trans-unit id="grid.sheet.customClasses" xml:space="preserve" approved="yes">
 				<source>Custom classes</source>
 			<target state="translated">Weitere class-Attribute</target></trans-unit>


### PR DESCRIPTION
- not sure, if this explicit namings fit the purpose. 
- EN may go in parallel in namings, but I did not change them
- if this approach is correct, one could still rename "desktop" into "Full HD", because it just implies this resolution nowadays.