### PR TITLE
Typo3 11 compatibility

### DIFF
--- a/Resources/Private/Templates/Standard/Accordion.html
+++ b/Resources/Private/Templates/Standard/Accordion.html
@@ -1,23 +1,21 @@
-<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-namespace-typo3-fluid="true">
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers" data-bs-namespace-typo3-fluid="true">
 
 <f:layout name="Default"/>
 
 <f:section name="Main">
     <f:if condition="{children}">
-        <div id="accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}">
+        <div id="accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}" class="accordion">
             <f:for each="{children}" as="columns" key="rowNumber">
                 <f:if condition="{columns.101}">
                     <f:for each="{columns.101}" as="child" iteration="iteration">
-                        <div class="card">
-                            <div class="card-header" id="heading-c{child.data.uid}">
-                                <h5 class="mb-0">
-                                    <button class="btn btn-link {f:if(condition:iteration.index,then:'',else:'collapsed')}" data-toggle="collapse" data-parent="#accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}" data-target="#collapse-{child.data.uid}" aria-expanded="false" aria-controls="collapse-{child.data.uid}">
-                                        {child.data.header}
-                                    </button>
-                                </h5>
-                            </div>
-                            <div id="collapse-{child.data.uid}" class="collapse {f:if(condition:iteration.index,then:'',else:'show')}" aria-labelledby="heading-c{child.data.uid}" data-parent="#accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}">
-                                <div class="card-body">
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="accordion-button-c{child.data.uid}">
+                                <button class="accordion-button" type="button" data-bs-toggle="collapse" data-bs-target="#collapse-{child.data.uid}" aria-expanded="true" aria-controls="#collapse-{child.data.uid}">
+                                    {child.data.header}
+                                </button>
+                            </h2>
+                            <div id="collapse-{child.data.uid}" class="accordion-collapse collapse" aria-labelledby="heading-c{child.data.uid}" data-bs-parent="#accordion-{f:if(condition:data._LOCALIZED_UID, then:data._LOCALIZED_UID, else:data.uid)}">
+                                <div class="accordion-body">
                                     <f:render partial="Child" arguments="{data: child.data, children: child.children, options: options, settings: settings}"/>
                                 </div>
                             </div>

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
   },
   "require": {
     "php": "^7.4 || ^8.0",
-    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
-    "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
+    "typo3/cms-core": "^10.4 || ^11.5",
+    "gridelementsteam/gridelements": "^10 || ^11.0.0"
   },
   "replace": {
     "typo3-ter/bootstrap-grids": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
   },
   "require": {
     "php": "^7.4 || ^8.0 || ^8.1",
-    "typo3/cms-core": "^10.4 || ^11.5",
+    "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
     "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
   },
   "replace": {

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,18 @@
 {
   "name": "laxap/bootstrap-grids",
   "type": "typo3-cms-extension",
-  "description": "Gridelements for bootstrap v4. Column grids, tabs and accordion.",
+  "description": "Gridelements for bootstrap v5. Column grids, tabs and accordion.",
   "license": "GPL-2.0-or-later",
-  "version": "2.2.0",
+  "version": "3.0.0",
   "keywords": ["typo3", "TYPO3 CMS", "bootstrap", "gridelements"],
   "homepage": "https://extensions.typo3.org/extension/bootstrap_grids/",
   "support": {
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
   "require": {
-    "php": "^7.2",
-    "typo3/cms-core": "^10.4",
-    "gridelementsteam/gridelements": "^10"
+    "php": "^7.4",
+    "typo3/cms-core": "^11.5",
+    "gridelementsteam/gridelements": "^11.0.0-dev"
   },
   "replace": {
     "typo3-ter/bootstrap-grids": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,10 @@
     "psr-4": {
       "Laxap\\BootstrapGrids\\": "Classes"
     }
-  }
+  },
+  "extra": {
+    "typo3/cms": {
+        "extension-key": "bootstrap_grids"
+    }
+}
 }

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
   "require": {
-    "php": "^7.4",
+    "php": "^8.0 || ^8.1",
     "typo3/cms-core": "^11.5",
     "gridelementsteam/gridelements": "^11.0.0-dev"
   },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": "^7.4 || ^8.0 || ^8.1",
     "typo3/cms-core": "^10.4 || ^11.5",
-    "gridelementsteam/gridelements": "^11.0.0-dev"
+    "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
   },
   "replace": {
     "typo3-ter/bootstrap-grids": "self.version"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
   "require": {
-    "php": "^8.0 || ^8.1",
-    "typo3/cms-core": "^11.5",
+    "php": "^7.4 || ^8.0 || ^8.1",
+    "typo3/cms-core": "^10.4 || ^11.5",
     "gridelementsteam/gridelements": "^11.0.0-dev"
   },
   "replace": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "issues": "https://github.com/laxap/bootstrap_grids/issues"
   },
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1",
+    "php": "^7.4 || ^8.0",
     "typo3/cms-core": "^9.5 || ^10.4 || ^11.5",
     "gridelementsteam/gridelements": "^9 || ^10 || ^11.0.0-dev"
   },

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '10.4.0-11.5.99',
-			'gridelements' => '9.0.0-11.99.99',
+			'gridelements' => '10.0.0-11.99.99',
 		],
 		'conflicts' => [],
         'suggests' => [],
@@ -29,5 +29,3 @@ $EM_CONF[$_EXTKEY] = [
         'psr-4' => ['Laxap\\BootstrapGrids\\' => 'Classes']
     ],
 ];
-
-?>

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = [
 	'constraints' => [
 		'depends' => [
 			'typo3' => '10.4.0-11.5.99',
-			'gridelements' => '11.0.0-10.99.99',
+			'gridelements' => '9.0.0-11.99.99',
 		],
 		'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -6,12 +6,12 @@
 
 $EM_CONF[$_EXTKEY] = [
 	'title' => 'Grids for bootstrap',
-	'description' => 'Gridelements for bootstrap v4. Column grids, tabs and accordion.',
+	'description' => 'Gridelements for bootstrap v5. Column grids, tabs and accordion.',
 	'category' => 'misc',
 	'author' => 'Pascal Mayer',
 	'author_email' => 'typo3@lascap.ch',
 	'author_company' => '',
-	'version' => '2.2.0',
+	'version' => '3.0.0',
 	'state' => 'stable',
 	'uploadfolder' => '0',
 	'createDirs' => '',
@@ -19,8 +19,8 @@ $EM_CONF[$_EXTKEY] = [
 	'clearCacheOnLoad' => 1,
 	'constraints' => [
 		'depends' => [
-			'typo3' => '10.4.0-10.4.99',
-			'gridelements' => '10.0.0-10.99.99',
+			'typo3' => '11.5.0-11.5.99',
+			'gridelements' => '11.0.0-10.99.99',
 		],
 		'conflicts' => [],
         'suggests' => [],

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -19,7 +19,7 @@ $EM_CONF[$_EXTKEY] = [
 	'clearCacheOnLoad' => 1,
 	'constraints' => [
 		'depends' => [
-			'typo3' => '11.5.0-11.5.99',
+			'typo3' => '10.4.0-11.5.99',
 			'gridelements' => '11.0.0-10.99.99',
 		],
 		'conflicts' => [],

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -2,7 +2,7 @@
 if (!defined('TYPO3_MODE')) { die('Access denied.'); }
 
 call_user_func(
-    function ($extConfString) {
+    function () {
 
         // register icons
         $iconRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Imaging\IconRegistry::class);
@@ -45,6 +45,6 @@ call_user_func(
         // Add pageTS config
         \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPageTSConfig('<INCLUDE_TYPOSCRIPT: source="FILE:EXT:bootstrap_grids/Configuration/TypoScript/pageTs/tsconfig.ts">');
 
-    },$_EXTCONF
+    }
 );
 ?>


### PR DESCRIPTION
Introduce compatibility to TYPO3 v11

This is based on [@okrener](https://github.com/okroener) changes in https://github.com/laxap/bootstrap_grids/pull/63.